### PR TITLE
Proposed fix for getPath returning Move.UP for trivial paths.

### DIFF
--- a/helper_package_python/map.py
+++ b/helper_package_python/map.py
@@ -91,7 +91,7 @@ class Map:
 			self.map[pHive[JSON_INDICES['HIVE']['Y']]][pHive[JSON_INDICES['HIVE']['X']]].ownerId = pHive[JSON_INDICES['HIVE']['OWNER_ID']]
 
 	def getPath(self, start, end):
-		path = Path()
+		path = Path(m=Move.STAY)
 		downDist = (self.height + end.y - start.y) % self.height
 		upDist = (self.height + start.y - end.y) % self.height
 		rightDist = (self.width + end.x - start.x) % self.width


### PR DESCRIPTION
Hello. I noticed that map.getPath() appears to return Move.UP if start and target are the same. I proposed a quick fix in this commit. This is currently for Python only, I haven't checked the JS and C++ code yet.

Regards,
Kira S